### PR TITLE
Fill in missing values when making factor

### DIFF
--- a/R/col_factor.R
+++ b/R/col_factor.R
@@ -6,6 +6,7 @@
 #' @param ... unquoted column names for modification
 #' @param .all if `TRUE` then any column with a `values` attribute or  where 
 #' the `make_factor` field evaluates to `TRUE` will be added as a factor
+#' @param .missing 
 #' @param .suffix used to make the column name for the factors
 #' @param values a vector of values to convert to a factor
 #' @param x a ycol object
@@ -31,10 +32,11 @@
 #' @md
 #' @export
 ys_add_factors <- function(.data, .spec, ... , 
-                           .all = TRUE, 
+                           .all = TRUE, .missing = NULL,
                            .suffix = getOption("ys.fct.suffix","_f")) {
   
   assert_that(inherits(.spec, "yspec"))
+  assert_that(is.null(.missing) || is.character(.missing))
   
   fct_ok <- map_lgl(.spec, ~ isTRUE(.x[["make_factor"]]))
   
@@ -49,7 +51,12 @@ ys_add_factors <- function(.data, .spec, ... ,
   
   for(v in vars) {
     newcol <- paste0(v, .suffix)
-    .data[[newcol]] <- ys_make_factor(.data[[v]],.spec[[v]],strict=!fct_ok[[v]])
+    .data[[newcol]] <- ys_make_factor(
+      .data[[v]],
+      .spec[[v]],
+      strict=!fct_ok[[v]], 
+      .missing = .missing
+    )
   }
   .data
 }
@@ -61,7 +68,10 @@ yspec_add_factors <- ys_add_factors
 #' @param strict if `FALSE`, then an factor will be returned for any `values` type
 #' @rdname ys_add_factors
 #' @export
-ys_make_factor <- function(values,x,strict=TRUE) {
+ys_make_factor <- function(values, x, strict = TRUE, .missing = NULL) {
+  if(is.factor(values)) {
+    return(values)
+  }
   if(is.null(x[["values"]])) {
     if(!strict) return(factor(values))
     stop("column: ", x[["col"]], " - values field is not found", call. = FALSE)
@@ -73,6 +83,11 @@ ys_make_factor <- function(values,x,strict=TRUE) {
     decode <- x[["values"]]
   } else {
     decode <- x[["decode"]]  
+  }
+  if(!is.null(.missing) && anyNA(values)) {
+    values[is.na(values)] <- .missing
+    x[["values"]] <- c(x[["values"]], .missing)
+    decode <- c(decode, .missing)
   }
   factor(values, levels = x[["values"]], labels = decode)
 }

--- a/R/col_factor.R
+++ b/R/col_factor.R
@@ -10,8 +10,6 @@
 #' the factor; keep this `NULL` (the default) to let missing values be handled
 #' naturally by `factor()`
 #' @param .suffix used to make the column name for the factors
-#' @param values a vector of values to convert to a factor
-#' @param x a ycol object
 #' 
 #' @details
 #' Note that `.suffix` can be chosen using option `ys.fct.suffix`. When the 
@@ -69,7 +67,9 @@ ys_add_factors <- function(.data, .spec, ... ,
 #' @export
 yspec_add_factors <- ys_add_factors
 
-#' @param strict if `FALSE`, then an factor will be returned for any `values` type
+#' @param values a vector of values to convert to a factor
+#' @param x a ycol object
+#' @param strict if `FALSE`, then a factor will be returned for any `values` type
 #' @rdname ys_add_factors
 #' @export
 ys_make_factor <- function(values, x, strict = TRUE, .missing = NULL) {

--- a/R/col_factor.R
+++ b/R/col_factor.R
@@ -6,13 +6,17 @@
 #' @param ... unquoted column names for modification
 #' @param .all if `TRUE` then any column with a `values` attribute or  where 
 #' the `make_factor` field evaluates to `TRUE` will be added as a factor
-#' @param .missing 
+#' @param .missing a label to use assign to missing values `NA` when making 
+#' the factor; keep this `NULL` (the default) to let missing values be handled
+#' naturally by `factor()`
 #' @param .suffix used to make the column name for the factors
 #' @param values a vector of values to convert to a factor
 #' @param x a ycol object
 #' 
 #' @details
-#' Note that `.suffix` can be chosen using option `ys.fct.suffix`. 
+#' Note that `.suffix` can be chosen using option `ys.fct.suffix`. When the 
+#' factor is made by [base::factor()], the `exclude` argument is forced to 
+#' `character(0)` so that nothing is excluded.
 #' 
 #' @examples
 #' 
@@ -89,7 +93,7 @@ ys_make_factor <- function(values, x, strict = TRUE, .missing = NULL) {
     x[["values"]] <- c(x[["values"]], .missing)
     decode <- c(decode, .missing)
   }
-  factor(values, levels = x[["values"]], labels = decode)
+  factor(values, levels = x[["values"]], labels = decode, exclude = character(0))
 }
 
 #' @rdname ys_add_factors

--- a/man/ys_add_factors.Rd
+++ b/man/ys_add_factors.Rd
@@ -12,6 +12,7 @@ ys_add_factors(
   .spec,
   ...,
   .all = TRUE,
+  .missing = NULL,
   .suffix = getOption("ys.fct.suffix", "_f")
 )
 
@@ -20,12 +21,13 @@ yspec_add_factors(
   .spec,
   ...,
   .all = TRUE,
+  .missing = NULL,
   .suffix = getOption("ys.fct.suffix", "_f")
 )
 
-ys_make_factor(values, x, strict = TRUE)
+ys_make_factor(values, x, strict = TRUE, .missing = NULL)
 
-yspec_make_factor(values, x, strict = TRUE)
+yspec_make_factor(values, x, strict = TRUE, .missing = NULL)
 }
 \arguments{
 \item{.data}{the data set to modify}
@@ -36,6 +38,10 @@ yspec_make_factor(values, x, strict = TRUE)
 
 \item{.all}{if \code{TRUE} then any column with a \code{values} attribute or  where
 the \code{make_factor} field evaluates to \code{TRUE} will be added as a factor}
+
+\item{.missing}{a label to use assign to missing values \code{NA} when making
+the factor; keep this \code{NULL} (the default) to let missing values be handled
+naturally by \code{factor()}}
 
 \item{.suffix}{used to make the column name for the factors}
 
@@ -49,7 +55,9 @@ the \code{make_factor} field evaluates to \code{TRUE} will be added as a factor}
 Add factors to data set based on spec information
 }
 \details{
-Note that \code{.suffix} can be chosen using option \code{ys.fct.suffix}.
+Note that \code{.suffix} can be chosen using option \code{ys.fct.suffix}. When the
+factor is made by \code{\link[base:factor]{base::factor()}}, the \code{exclude} argument is forced to
+\code{character(0)} so that nothing is excluded.
 }
 \examples{
 

--- a/man/ys_add_factors.Rd
+++ b/man/ys_add_factors.Rd
@@ -49,7 +49,7 @@ naturally by \code{factor()}}
 
 \item{x}{a ycol object}
 
-\item{strict}{if `FALSE`, then an factor will be returned for any `values` type}
+\item{strict}{if `FALSE`, then a factor will be returned for any `values` type}
 }
 \description{
 Add factors to data set based on spec information

--- a/tests/testthat/test-col_factor.R
+++ b/tests/testthat/test-col_factor.R
@@ -52,3 +52,13 @@ test_that("ys_add_factors aliases yspec_add_factors", {
   expect_identical(a,b)
 })
 
+test_that("NA handling by ys_add_factors", {
+  dat1 <- ys_help$data()
+  sp <- ys_help$spec()
+  dat1$RF[c(3,10,30)] <- NA_character_
+  dat2 <- dat1
+  a <- yspec_add_factors(dat1, sp, RF)
+  expect_identical(levels(a$RF_f), sp$RF$decode)
+  b <- yspec_add_factors(dat2, sp, RF, .missing = "Missing")
+  expect_identical(levels(b$RF_f), c(sp$RF$decode, "Missing"))
+})


### PR DESCRIPTION
# Summary

When calling `ys_add_factors()`, look for missing values and fill in if requested
- User must specify the label for missing values to opt in (new argument is `.missing`, which must be `NULL` or `character(0)`
- The missing values are the last level
- We also now return early when we already have a factor

# Reprex

``` r
library(tidyverse)
library(yspec)


spec <- ys_help$spec()
data <- ys_help$data()

data$RF[c(3,10,32)] <- NA_character_
count(data, RF)
#>     RF    n
#> 1 mild  360
#> 2  mod  360
#> 3 norm 3277
#> 4  sev  360
#> 5 <NA>    3

data <- ys_add_factors(data, spec, .missing = "Missing")

count(data, RF_f)
#>       RF_f    n
#> 1   Normal 3277
#> 2     Mild  360
#> 3 Moderate  360
#> 4   Severe  360
#> 5  Missing    3
```

<sup>Created on 2021-08-13 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>