### PR TITLE
add argument to ys_prune

### DIFF
--- a/R/class-yspec.R
+++ b/R/class-yspec.R
@@ -437,6 +437,10 @@ ys_add_labels <- function(data,spec,fun=label.ycol) {
 #' 
 #' @param data a data frame with at least one column that is found in `spec`
 #' @param spec a `yspec` object
+#' @param add additional columns to look for; this can be a comma-separated 
+#' character string or vector; if specified, these names will be treated like 
+#' any other name in `spec`, specifically missing names will be silently 
+#' ignored unless `report` is passed as `TRUE`
 #' @param report if `TRUE`, report missing columns
 #' 
 #' @examples
@@ -462,18 +466,22 @@ ys_add_labels <- function(data,spec,fun=label.ycol) {
 #'   
 #' @md
 #' @export
-ys_prune <- function(data, spec, report = FALSE) {
+ys_prune <- function(data, spec, add = NULL, report = FALSE) {
   assert_that(is.data.frame(data))
   assert_that(is_yspec(spec))
   # spec positions for matching names in the data set
-  igrab <- sort(match(names(data), names(spec)), na.last = NA)
+  target <- names(spec)
+  if(is.character(add)) {
+    target <- c(target, cvec_cs(add))  
+  }
+  igrab <- sort(match(names(data), target), na.last = NA)
   if(length(igrab)==0) {
     stop("there are no names common between `data` and `spec`", call. = FALSE)  
   }
   # convert igrab to names in spec, ordered by spec; this is what we'll take
-  grab <- names(spec)[igrab]
+  grab <- target[igrab]
   if(isTRUE(report)) {
-    missing <- setdiff(names(spec), names(data))
+    missing <- setdiff(target, names(data))
     for(col in missing) {
       message("Column not found: ", col)  
     }

--- a/man/ys_prune.Rd
+++ b/man/ys_prune.Rd
@@ -4,12 +4,17 @@
 \alias{ys_prune}
 \title{Prune a data frame, keeping columns in a yspec object}
 \usage{
-ys_prune(data, spec, report = FALSE)
+ys_prune(data, spec, add = NULL, report = FALSE)
 }
 \arguments{
 \item{data}{a data frame with at least one column that is found in \code{spec}}
 
 \item{spec}{a \code{yspec} object}
+
+\item{add}{additional columns to look for; this can be a comma-separated
+character string or vector; if specified, these names will be treated like
+any other name in \code{spec}, specifically missing names will be silently
+ignored unless \code{report} is passed as \code{TRUE}}
 
 \item{report}{if \code{TRUE}, report missing columns}
 }

--- a/tests/testthat/test-prune.R
+++ b/tests/testthat/test-prune.R
@@ -21,6 +21,10 @@ test_that("ys_prune selects available columns", {
     ys_prune(data.frame(a = 2), spec), 
     regexp = "there are no names common between"
   )
+  ans <- ys_prune(data, spec, add = "BAR")
+  expect_equal(names(ans), c(names(spec2), "BAR"))
+  ans <- ys_prune(data, spec, add = "BLAH,FOO")
+  expect_equal(names(ans), c(names(spec2), "FOO"))
   expect_message(
     ans <- ys_prune(data, spec, report = TRUE), 
     regexp = "Column not found: STUDY", 


### PR DESCRIPTION
# Summary

- I merged and nuked the previous ys_prune branch too soon
- This adds an `add` argument to tack on additional names to look for
- Like unmatched names in the spec, unmatched names in `add` are silently ignored unless the user requests a `report`
