### PR TITLE
Return length-zero yspec if nothing selected

### DIFF
--- a/R/fda_define.R
+++ b/R/fda_define.R
@@ -333,7 +333,3 @@ render_fda_define.yspec <- function(x, ..., dots = list()) {
   proj <- do.call(ys_project, dots)
   render_fda_define.yproj(proj,...)  
 }
-
-
-
-

--- a/R/ys-tidy.R
+++ b/R/ys-tidy.R
@@ -10,16 +10,21 @@
 #' ys_select(spec, WT, AGE, ALB)
 #' 
 #' ys_select(spec, Wt = WT, AGE)
+#'  
+#' length(ys_select(spec))
+#'  
+#' @details
+#' If no columns are selected, then an empty `yspec` object is returned. 
 #' 
 #' @return 
-#' A `yspec` object
+#' A `yspec` object that may be length zero if no columns were selected. 
 #' 
 #' @md
 #' @export
 ys_select <- function(.x, ...) {
   keep <- eval_select(expr(c(...)), as.list(.x))
   if(length(keep)==0) {
-    return(.x) 
+    return(.x[NULL]) 
   }
   original <- names(.x)[keep]
   ans <- .x[original]

--- a/man/ys_select.Rd
+++ b/man/ys_select.Rd
@@ -12,10 +12,13 @@ ys_select(.x, ...)
 \item{...}{unquoted columns to select}
 }
 \value{
-A \code{yspec} object
+A \code{yspec} object that may be length zero if no columns were selected.
 }
 \description{
 Select a subset of columns from a yspec object
+}
+\details{
+If no columns are selected, then an empty \code{yspec} object is returned.
 }
 \examples{
 
@@ -24,5 +27,7 @@ spec <- ys_help$spec()
 ys_select(spec, WT, AGE, ALB)
 
 ys_select(spec, Wt = WT, AGE)
-
+ 
+length(ys_select(spec))
+ 
 }

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -6,11 +6,21 @@ context("test-select")
 
 test_that("select column subset", {
   spec <- ys_help$spec()
-  spec2 <- ys_select(spec)
-  expect_identical(spec,spec2)
+  # spec2 <- ys_select(spec)
+  # expect_identical(spec,spec2)
   spec3 <- ys_select(spec, WT, AGE, ALB)
   expect_identical(names(spec3), c("WT", "AGE", "ALB"))
   expect_is(spec3, "yspec")
   expect_error(ys_select(spec, kyle))
+})
+
+test_that("select with no matching names returns zero-length yspec", {
+  spec <- ys_help$spec()
+  spec <- ys_select(spec, character(0))
+  expect_length(spec, 0)
+  expect_is(spec, "yspec")
+  m <- get_meta(spec)
+  expect_is(m, "list")
+  expect_true(length(m) > 0)
 })
 


### PR DESCRIPTION
# Summary

- This changes behavior so that length-zero yspec object is returned if nothing is selected

Reviewers: please think though if this should be the new behavior (I believe it is but want to critically think it through). Thanks!

# New Behavior
``` r
library(yspec)


spec <- ys_select(ys_help$spec())
length(spec)
#> [1] 0
spec
#> [1] name   c      d      unit   short  source
#> <0 rows> (or 0-length row.names)
names(get_meta(spec))
#>  [1] "description"     "sponsor"         "projectnumber"   "use_internal_db"
#>  [5] "glue"            "flags"           "lookup_file"     "spec_file"      
#>  [9] "spec_path"       "name"            "data_stem"       "data_path"      
#> [13] "primary_key"     "control"         "namespace"
```

<sup>Created on 2022-01-06 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>