### PR TITLE
fixed typo in accessing control element

### DIFF
--- a/R/load_spec.R
+++ b/R/load_spec.R
@@ -111,7 +111,7 @@ check_this_col <- function(x, col, env, control, ...) {
     }
   }
   if(sum(nchar(x$short)) > control[["max_nchar_short"]]) {
-    nmax <- control[["max_char_short"]]
+    nmax <- control[["max_nchar_short"]]
     msg <- "the 'short' field should not be longer than {nmax} characters"
     err <- c(err, as.character(glue(msg)))
   }

--- a/tests/testthat/test-load_spec.R
+++ b/tests/testthat/test-load_spec.R
@@ -68,6 +68,8 @@ test_that("error if column name is greater than 8 characters", {
   options(ys.col.len = NULL)
 })
 
+
+
 test_that("error if unit, type, or short are gt length 1 issue-45", {
   expect_error(yspec:::test_spec_test("issue-45.yml"), 
                regexp="should not be more than length 1") 
@@ -87,6 +89,14 @@ test_that("access label", {
 test_that("error if label greater than 40 characters", {
   expect_error(yspec:::test_spec_error("long_label.yml"),
                regexp = "should not be longer than 40 characters") 
+})
+
+test_that("error if short greater than 40 characters", {
+  lbl <- paste0(letters, collapse = " ")
+  expect_error(
+    test_spec_list(list(A = list(short = lbl))), 
+    regexp = "the 'short' field should not be longer than 40"
+  )
 })
 
 test_that("collapse source, comment, long issue-46", {


### PR DESCRIPTION
Fixing typo when accessing that `control` object.  Added test for when short is too long.