### PR TITLE
Fix/non atomic values

### DIFF
--- a/R/class-ycol.R
+++ b/R/class-ycol.R
@@ -14,7 +14,7 @@ print.ycol <- function(x,...) {
     if(.has("values", x)) {
       valu <- x[["values"]]
       mx <- max(nchar(valu))
-      valu <- formatC(valu,width=mx,flag="-")
+      valu <- formatC(valu, width = mx, flag = "-")
       if(.has("decode", x)) {
         valu <- paste(valu, x[["decode"]], sep = " : ")
       }

--- a/R/load_spec.R
+++ b/R/load_spec.R
@@ -76,7 +76,11 @@ check_this_col <- function(x, col, env, control, ...) {
       err <- c(err, "values field includes NULLs")  
     }
     if(any(x[["values"]] == "<yspec-not-atomic>")) {
-      err <- c(err, "values field includes non-atomic data")  
+      errx <- c(
+        "values field includes non-atomic data .... ", 
+        "yaml code possibly used brackets [ ] when braces { } were intended"
+      )
+      err <- c(err, errx)  
     }
   }
   if(.has("values", x) & .has("range",x)) {

--- a/R/load_spec.R
+++ b/R/load_spec.R
@@ -72,9 +72,6 @@ check_spec_input <- function(x, .fun = check_spec_input_col,
 check_this_col <- function(x, col, env, control, ...) {
   err <- c()
   if(.has("values",x)) {
-    if(is.list(x[["values"]])) {
-      err <- c(err, "values is a list; it was likely mis-coded in the spec file")  
-    }
     if(any(x[["values"]] == "<yspec-null>")) {
       err <- c(err, "values field includes NULLs")  
     }

--- a/R/load_spec.R
+++ b/R/load_spec.R
@@ -77,7 +77,7 @@ check_this_col <- function(x, col, env, control, ...) {
     }
     if(any(x[["values"]] == "<yspec-not-atomic>")) {
       errx <- c(
-        "values field includes non-atomic data .... ", 
+        "values field includes non-atomic data ... ", 
         "yaml code possibly used brackets [ ] when braces { } were intended"
       )
       err <- c(err, errx)  
@@ -348,7 +348,7 @@ unpack_col <- function(x) {
     if(!.has("decode",x)) {
       x$decode <- names(x$values)
     }
-    x$values <- sapply(x$values, sub_null, USE.NAMES=FALSE)
+    x$values <- sapply(x$values, sub_null_natom, USE.NAMES=FALSE)
     if(is.character(x$values)) x$type <- "character"
   }
   if(.has("source", x)) {
@@ -364,9 +364,10 @@ unpack_col <- function(x) {
   structure(x, class = "ycol")
 }
 
-sub_null <- function(x) {
+sub_null_natom <- function(x) {
   if(!is.atomic(x)) return("<yspec-not-atomic>")
-  ifelse(is.null(x), "<yspec-null>", x)
+  if(is.null(x)) return("<yspec-null>")
+  return(x)
 }
 
 col_initialize <- function(x, name) {

--- a/R/load_spec.R
+++ b/R/load_spec.R
@@ -72,11 +72,17 @@ check_spec_input <- function(x, .fun = check_spec_input_col,
 check_this_col <- function(x, col, env, control, ...) {
   err <- c()
   if(.has("values",x)) {
+    if(is.list(x[["values"]])) {
+      err <- c(err, "values is a list; it was likely mis-coded in the spec file")  
+    }
     if(any(x[["values"]] == "<yspec-null>")) {
       err <- c(err, "values field includes NULLs")  
     }
+    if(any(x[["values"]] == "<yspec-not-atomic>")) {
+      err <- c(err, "values field includes non-atomic data")  
+    }
   }
-  if(.has("values",x) & .has("range",x)) {
+  if(.has("values", x) & .has("range",x)) {
     err <- c(err, "column has both values and range")
   }
   if(.has("decode",x)) {
@@ -87,7 +93,6 @@ check_this_col <- function(x, col, env, control, ...) {
       )
     }
   }
-  
   if(length(x$unit) > 1) {
     err <- c(err, "the 'unit' field should not be more than length 1")  
   }
@@ -359,6 +364,7 @@ unpack_col <- function(x) {
 }
 
 sub_null <- function(x) {
+  if(!is.atomic(x)) return("<yspec-not-atomic>")
   ifelse(is.null(x), "<yspec-null>", x)
 }
 

--- a/inst/internal/ysdb_internal.yml
+++ b/inst/internal/ysdb_internal.yml
@@ -22,7 +22,7 @@ CMT:
   type: numeric
 EVID:
   short: event ID
-  values: [observation: 0, dose: 1]
+  values: {observation: 0, dose: 1}
 AMT: 
   short: dose amount
   type: numeric
@@ -39,7 +39,7 @@ SS:
     - non-steady state indicator
     - steady state indicator
 MDV:
-  values: [non-missing: 0, missing: 1]
+  values: {non-missing: 0, missing: 1}
   type: numeric
   long: missing DV indicator
   comment: per NONMEM specifications

--- a/inst/spec/test/values-list-of-lists.yml
+++ b/inst/spec/test/values-list-of-lists.yml
@@ -1,0 +1,2 @@
+EVID: 
+  values: [a: 1, b: 2]

--- a/tests/testthat/test-load_spec.R
+++ b/tests/testthat/test-load_spec.R
@@ -102,3 +102,9 @@ test_that("error to pass non-character file name", {
   expect_error(ys_load(x))
 })
 
+test_that("Error when values is mis-coded", {
+  expect_error(
+  yspec:::test_spec_test("values-list-of-lists.yml"), 
+  regexp="values field includes non-atomic data"
+  )
+})

--- a/tests/testthat/test-load_spec.R
+++ b/tests/testthat/test-load_spec.R
@@ -102,9 +102,9 @@ test_that("error to pass non-character file name", {
   expect_error(ys_load(x))
 })
 
-test_that("Error when values is mis-coded", {
+test_that("Error when values is mis-coded as list of lists", {
   expect_error(
   yspec:::test_spec_test("values-list-of-lists.yml"), 
-  regexp="values field includes non-atomic data"
+  regexp = "values field includes non-atomic data"
   )
 })


### PR DESCRIPTION
# Summary 
Basically, when values are coded like this: 

`values: [ male: 1, female: 2]` 

yaml returns a list of lists; the correct coding is 

`values: {male: 1, female: 2}`

This PR implements a check for `values` to make sure they are atomic and generates an error when not. 