### PR TITLE
allow a tidy selection syntax

### DIFF
--- a/R/col_factor.R
+++ b/R/col_factor.R
@@ -3,7 +3,8 @@
 #' 
 #' @param .data the data set to modify
 #' @param .spec a yspec object
-#' @param ... unquoted column names for modification
+#' @param ... unquoted column names for modification; passing nothing through 
+#' `...` will signal for all columns to be considered for factors
 #' @param .all if `TRUE` then any column with a `values` attribute or  where 
 #' the `make_factor` field evaluates to `TRUE` will be added as a factor
 #' @param .missing a label to use assign to missing values `NA` when making 
@@ -43,7 +44,11 @@ ys_add_factors <- function(.data, .spec, ... ,
   fct_ok <- map_lgl(.spec, ~ isTRUE(.x[["make_factor"]]))
   
   what <- exprs(...)
-  what <- map_chr(what,as_string)
+  
+  if(length(what) > 0) {
+    what <- names(eval_select(expr(c(...)), .data))
+  } 
+
   if(length(what)==0 & isTRUE(.all)) {
     dis <- map_lgl(.spec, ~!is.null(.x[["values"]]))
     spec_cols <- names(which(dis | fct_ok))
@@ -58,7 +63,7 @@ ys_add_factors <- function(.data, .spec, ... ,
     .data[[newcol]] <- ys_make_factor(
       .data[[v]],
       .spec[[v]],
-      strict=!fct_ok[[v]], 
+      strict = !fct_ok[[v]], 
       .missing = .missing
     )
   }

--- a/man/ys_add_factors.Rd
+++ b/man/ys_add_factors.Rd
@@ -34,7 +34,8 @@ yspec_make_factor(values, x, strict = TRUE, .missing = NULL)
 
 \item{.spec}{a yspec object}
 
-\item{...}{unquoted column names for modification}
+\item{...}{unquoted column names for modification; passing nothing through
+\code{...} will signal for all columns to be considered for factors}
 
 \item{.all}{if \code{TRUE} then any column with a \code{values} attribute or  where
 the \code{make_factor} field evaluates to \code{TRUE} will be added as a factor}

--- a/tests/testthat/test-col_factor.R
+++ b/tests/testthat/test-col_factor.R
@@ -76,3 +76,16 @@ test_that("OK to have missing or extra cols in .data", {
   expect_is(dat2, "data.frame")
   expect_equal(sort(diff), sort(c("RF_f", "CP_f", "RF", "CP")))
 })
+
+test_that("tidyselect semantics when identifying columns for factor", {
+  data <- ys_help$data()
+  spec <- ys_help$spec()
+  
+  ans <- ys_add_factors(data, spec, tidyselect::contains("RF"))
+  expect_true("RF_f" %in% names(ans))
+  
+  ans <- ys_add_factors(data, spec, BLQ:STUDY)
+  expect_true("BLQ_f" %in% names(ans))
+  expect_true("PHASE_f" %in% names(ans))
+  expect_true("STUDY_f" %in% names(ans))
+})


### PR DESCRIPTION
# Summary

This PR adds a bit of code inside `ys_add_factors` that enables tidyselect syntax to be used in `...`

