### PR TITLE
ys_table switches to tex namespace by default

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: yspec
 Type: Package
 Title: Data Specification for Pharmacometrics
-Version: 0.5.2
+Version: 0.5.2.9000
 Authors@R: c(
        person("Kyle T", "Baron", "", 
               "kyleb@metrumrg.com", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# yspec (development version)
+
 # yspec 0.5.2
 
 - Adds `ys_extend()` to extend a spec object with additional 

--- a/R/fda_define.R
+++ b/R/fda_define.R
@@ -342,11 +342,11 @@ render_fda_define.yspec <- function(x, ..., dots = list()) {
 #' 
 #' The primary use case for this function is for creating TeX tables which can 
 #' be included in a report Appendix. See more in `details`.
-#' 
-#' @param spec a `yspec` object
 #'
+#' @param spec a `yspec` object
 #' @param fun a function to format a TeX table; if `NULL` (the default), the 
 #' table will be rendered using [fda_table()]
+#' @param tex logical; if `TRUE`, switch to `tex` namespace if it exists
 #' @param widths_ passed to [fda_table()] when `fun` is `NULL`; these are 
 #' slightly modified from the [fda_table()] default (see `examples`); note 
 #' the trailing underscore in the argument name; these shouldn't need to be 
@@ -375,9 +375,10 @@ render_fda_define.yspec <- function(x, ..., dots = list()) {
 #' 
 #' @md
 #' @export
-ys_table <- function(spec, fun = NULL, 
+ys_table <- function(spec, fun = NULL, tex = TRUE, 
                      widths_ = c(0.75, 1.95, 0.6, 2.15), ...) {
   assert_that(is_yspec(spec))
+  spec <- try_tex_namespace(spec)
   if(is.null(fun)) {
     tab <- fda_table(spec, widths = widths_, ...)  
   } else {

--- a/man/ys_table.Rd
+++ b/man/ys_table.Rd
@@ -4,13 +4,15 @@
 \alias{ys_table}
 \title{Create a table from yspec object}
 \usage{
-ys_table(spec, fun = NULL, widths_ = c(0.75, 1.95, 0.6, 2.15), ...)
+ys_table(spec, fun = NULL, tex = TRUE, widths_ = c(0.75, 1.95, 0.6, 2.15), ...)
 }
 \arguments{
 \item{spec}{a \code{yspec} object}
 
 \item{fun}{a function to format a TeX table; if \code{NULL} (the default), the
 table will be rendered using \code{\link[=fda_table]{fda_table()}}}
+
+\item{tex}{logical; if \code{TRUE}, switch to \code{tex} namespace if it exists}
 
 \item{widths_}{passed to \code{\link[=fda_table]{fda_table()}} when \code{fun} is \code{NULL}; these are
 slightly modified from the \code{\link[=fda_table]{fda_table()}} default (see \code{examples}); note


### PR DESCRIPTION
Put in a switch to `tex` namespace by default; this is what `ys_document()` does and `ys_table` should follow suit. 