### PR TITLE
Fix/type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ TARBALL=${PACKAGE}_${VERSION}.tar.gz
 PKGDIR=.
 CHKDIR=.
 
+testn: 
+	Rscript inst/validation/latest.R
+
 # development cycle - bumps the version and tags based on version
 bump-dev:
 	Rscript -e 'usethis::use_version("dev")'

--- a/R/load_spec.R
+++ b/R/load_spec.R
@@ -350,7 +350,9 @@ unpack_col <- function(x) {
       x$decode <- names(x$values)
     }
     x$values <- sapply(x$values, sub_null_natom, USE.NAMES=FALSE)
-    if(is.character(x$values)) x$type <- "character"
+    if(is.character(x$values) && .no("type", x)) {
+      x$type <- "character"
+    }
   }
   if(.has("source", x)) {
     x$source <- paste0(x$source, collapse = " ")  

--- a/R/load_spec.R
+++ b/R/load_spec.R
@@ -333,9 +333,6 @@ unpack_col <- function(x) {
   if(.no("short",x)) {
     x[["short"]] <- x[["col"]]
   }
-  if(.no("type", x)) {
-    x[["type"]] <- "numeric"
-  }
   x <- unpack_about(x)
   x$continuous <- .has("range",x)
   if(x$continuous) {
@@ -349,10 +346,13 @@ unpack_col <- function(x) {
     if(!.has("decode",x)) {
       x$decode <- names(x$values)
     }
-    x$values <- sapply(x$values, sub_null_natom, USE.NAMES=FALSE)
+    x$values <- sapply(x$values, sub_null_natom, USE.NAMES = FALSE)
     if(is.character(x$values) && .no("type", x)) {
       x$type <- "character"
     }
+  }
+  if(.no("type", x)) {
+    x[["type"]] <- "numeric"
   }
   if(.has("source", x)) {
     x$source <- paste0(x$source, collapse = " ")  

--- a/inst/validation/latest.R
+++ b/inst/validation/latest.R
@@ -1,0 +1,15 @@
+library(yaml)
+
+x <- yaml.load_file("inst/validation/yspec-stories.yaml")
+
+stories <- names(x)
+stories <- sub("YSP-S", "", stories)
+stories <- as.integer(stories)
+
+tests <- unlist(lapply(x,  function(x) x$tests), use.names=FALSE)
+dupt <- any(duplicated(tests))
+tests <- sub("YSP-TEST-", "", tests)
+tests <- as.integer(tests)
+
+message("last story: ", max(stories))
+message("last test: ", max(tests))

--- a/inst/validation/yspec-stories.yaml
+++ b/inst/validation/yspec-stories.yaml
@@ -1,3 +1,13 @@
+YSP-S034:
+  name: ys_load - only assume character type if type is NULL
+  description: > 
+    As a user, I want yspec to infer that type is character for discrete 
+    data when type is missing and the values field has type character.
+  ProductRisk: low-risk
+  tests: YSP-TEST-0145
+
+
+# --------
 YSP-S001:
   name: Make ys_get_short_unit return list
   description: ys_get_short_unit returns list not character vector

--- a/tests/testthat/test-load_spec.R
+++ b/tests/testthat/test-load_spec.R
@@ -119,3 +119,19 @@ test_that("Error when values is mis-coded as list of lists [YSP-TEST-0072]", {
   )
 })
 
+test_that("ys_load - only assume character type if type is NULL [YSP-TEST-0145]", {
+  spec <- yspec:::test_spec_list(
+    list(A = list(values = letters[1:3]))
+  )
+  expect_equal(spec$A$type, "character")
+  
+  spec <- yspec:::test_spec_list(
+    list(A = list(values = c(1,2,3), type = "integer"))
+  )
+  expect_equal(spec$A$type, "integer")
+  
+  spec <- yspec:::test_spec_list(
+    list(A = list(values = letters[1:3], type = "integer"))
+  )
+  expect_equal(spec$A$type, "integer")
+})


### PR DESCRIPTION
# Summary

- There was logic in `ys_load()` to assume character type if `values` was character
- I'm not crazy about this right now but keeping it 
- The change is to _NOT_ do this when the user does pass the type


E.g. 

```yaml
STUDY: 
  values: 
  - "101"
  - "201"
  type: "integer"
```

The type in this case should be `integer`