### PR TITLE
Release 0.6.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: yspec
 Type: Package
 Title: Data Specification for Pharmacometrics
-Version: 0.6.0.9001
+Version: 0.6.1
 Authors@R: c(
        person("Kyle T", "Baron", "", 
               "kyleb@metrumrg.com", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# yspec (development version)
+# yspec 0.6.1
 
 - Use `all_of()` when tidy selecting; this will suppress warnings in 
   `ys_extend()` and `ys_add_factors()` (#145).


### PR DESCRIPTION
# yspec 0.6.1

- Use `all_of()` when tidy selecting; this will suppress warnings in 
  `ys_extend()` and `ys_add_factors()` (#145).