### PR TITLE
Release/0.6.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: yspec
 Type: Package
 Title: Data Specification for Pharmacometrics
-Version: 0.6.1.9000
+Version: 0.6.2
 Authors@R: c(
        person("Kyle T", "Baron", "", 
               "kyleb@metrumrg.com", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# yspec (development version)
+# yspec 0.6.2
 
 # yspec 0.6.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 
 ## Breaking changes
 
-- `nm_input` was significantly refactored to produce output more typically seen 
+- `nm_input()` was significantly refactored to produce output more typically seen 
   in practice as well as adding some convenience features
     - the default output is now wide format
     - data set labels can get renamed with `<new name> = <old name>` syntax, passed

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,22 @@
 # yspec 0.6.2
 
+
+## Breaking changes
+
+- `nm_input` was significantly refactored to produce output more typically seen 
+  in practice as well as adding some convenience features
+    - the default output is now wide format
+    - data set labels can get renamed with `<new name> = <old name>` syntax, passed
+      under `...`
+    - columns with type `<character>` are dropped by default
+    - the `cat` argument was renamed `.cat`
+    - the `.drop` argument was added to indicate a group of data items to drop 
+      from the problem
+    - the previous long output can be recreated using `.long = TRUE`
+    - the `.decodes` argument was added to control appearance of categorical data 
+      decode information in the long output
+
+
 # yspec 0.6.1
 
 - Use `all_of()` when tidy selecting; this will suppress warnings in 
@@ -8,7 +25,7 @@
 # yspec 0.6.0
 
 - Adds `ys_factors()` to _replace_ data set columns with their factor version, 
-  optionally retaining the orignal values in new columns (#141).
+  optionally retaining the original values in new columns (#141).
 
 # yspec 0.5.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,9 @@
 # yspec 0.6.2
 
-
 ## Breaking changes
 
 - `nm_input()` was significantly refactored to produce output more typically seen 
-  in practice as well as adding some convenience features
+  in practice as well as adding some convenience features (#150).
     - the default output is now wide format
     - data set labels can get renamed with `<new name> = <old name>` syntax, passed
       under `...`
@@ -15,7 +14,6 @@
     - the previous long output can be recreated using `.long = TRUE`
     - the `.decodes` argument was added to control appearance of categorical data 
       decode information in the long output
-
 
 # yspec 0.6.1
 


### PR DESCRIPTION
# yspec 0.6.2


## Breaking changes

- `nm_input()` was significantly refactored to produce output more typically seen 
  in practice as well as adding some convenience features (#150).
    - the default output is now wide format
    - data set labels can get renamed with `<new name> = <old name>` syntax, passed
      under `...`
    - columns with type `<character>` are dropped by default
    - the `cat` argument was renamed `.cat`
    - the `.drop` argument was added to indicate a group of data items to drop 
      from the problem
    - the previous long output can be recreated using `.long = TRUE`
    - the `.decodes` argument was added to control appearance of categorical data 
      decode information in the long output