### PR TITLE
Adjust for glue 1.8.0 compatibility

### DIFF
--- a/R/fda_define.R
+++ b/R/fda_define.R
@@ -98,10 +98,7 @@ fda_table <- function(x, widths = c(0.75, 2.1, 0.6, 2.2), ...) {
       sanitize.text.function = getOption("ys.sanitize", ys_sanitize)
     )
   )
-  glu <- get_meta(x)[["glue"]]
-  if(is.list(glu)) {
-    ans <- sapply(ans, glue, .envir = glu, .open = .glopen, .close = .glclose)
-  }
+  ans <- yspec_glue(x, ans)
   unname(ans)
 }
 

--- a/R/pander_table.R
+++ b/R/pander_table.R
@@ -34,10 +34,7 @@ x_table <- function(x,...) {
       sanitize.text.function = getOption("ys.sanitize", ys_sanitize)
     )
   )
-  glu <- get_meta(x)[["glue"]]
-  if(is.list(glu)) {
-    ans <- sapply(ans, glue, .envir = glu, .open = .glopen, .close = .glclose)
-  }
+  ans <- yspec_glue(x, ans)
   ans
 }
 
@@ -61,10 +58,7 @@ x_table_long <- function(x,...) {
       sanitize.text.function = getOption("ys.sanitize", ys_sanitize)
     )
   )
-  glu <- get_meta(x)[["glue"]]
-  if(is.list(glu)) {
-    ans <- sapply(ans, glue, .envir = glu, .open = .glopen, .close = .glclose)
-  }
+  ans <- yspec_glue(x, ans)
   ans
 }
 
@@ -105,11 +99,7 @@ pander_table <- function(x, ...) {
     split.cells = c("22%","15%","22%","41%"),
     style = "multiline"
   )
-  glu <- get_meta(x)[["glue"]]
-  
-  if(is.list(glu)) {
-    ans <- sapply(ans, glue, .envir = glu, .open = .glopen, .close = .glclose)
-  }
+  ans <- yspec_glue(x, ans)
   
   ans
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -360,8 +360,8 @@ yspec_glue <- function(spec, txt) {
   glu <- get_meta(spec)[["glue"]]
   if (is.list(glu)) {
     txt <- sapply(
-      txt, glue,
-      .envir = glu, .open = .glopen, .close = .glclose
+      txt, glue::glue_data,
+      .x = glu, .envir = emptyenv(), .open = .glopen, .close = .glclose
     )
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -355,3 +355,15 @@ temp_spec <- function(text, name) {
   writeLines(text, con = file)
   return(invisible(file))
 }
+
+yspec_glue <- function(spec, txt) {
+  glu <- get_meta(spec)[["glue"]]
+  if (is.list(glu)) {
+    txt <- sapply(
+      txt, glue,
+      .envir = glu, .open = .glopen, .close = .glclose
+    )
+  }
+
+  return(txt)
+}

--- a/R/x_table_2.R
+++ b/R/x_table_2.R
@@ -18,7 +18,7 @@ x_table_2_details <- function(x) {
 x_table_2_table_row <- function(x,details_fun) {
   unit <- NULL
   if(.has("unit",x)) {
-    unit <- glue::glue(" ({unit})", .envir = x)
+    unit <- glue::glue_data(x, " ({unit})", .envir = emptyenv())
   }
   short <- paste0(label.ycol(x,default = "short"),unit)
   ans <- tibble( 

--- a/R/x_table_2.R
+++ b/R/x_table_2.R
@@ -74,6 +74,6 @@ x_table_2 <- function(spec,
     table.placement = "H",
     sanitize.text.function = getOption("ys.sanitize", ys_sanitize)
   )
-  pxt <- glue::glue(pxt, .envir=get_meta(spec)$glue, .open = "<<", .close = ">>")
+  pxt <- yspec_glue(spec, pxt)
   return(pxt)  
 }


### PR DESCRIPTION
This PR updates yspec to be compatible with glue 1.8.0, which no longer accepts a list for its `.envir` argument.

As described in the second commit message, this PR introduces a change in the lookup behavior, eliminating a case where the value could come from the global environment.  (In my view, it's acceptable and can be considered a fix.)

Related PRs:

 * https://github.com/metrumresearchgroup/pmtables/pull/346

 * https://github.com/metrumresearchgroup/mrggsave/pull/44
