### PR TITLE
summary.yspec: avoid failure on zero-length object

### DIFF
--- a/R/class-yspec.R
+++ b/R/class-yspec.R
@@ -150,7 +150,7 @@ summary.yspec <- function(object, ...) {
   if(any(ext != ".")) {
     out$source[ext != '.'] <- ext[ext != '.']
     out$info <- paste0(out$info, ifelse(ext == '.', "-", "e"))
-  } else {
+  } else if (length(out$info)) {
     out$info <- paste0(out$info, "-")  
   }
   out$source <- sub("\\.ya?ml$", "", out$source)

--- a/tests/testthat/test-yspec.R
+++ b/tests/testthat/test-yspec.R
@@ -30,6 +30,20 @@ test_that("yspec methods [YSP-TEST-0135]", {
   expect_true(grepl("^ STUDY", pr[14]))
 })
 
+test_that("summary.yspec handles zero-length object", {
+  expect_identical(
+    summary(spec[NULL]),
+    data.frame(
+      name = character(),
+      info = character(),
+      unit = character(),
+      short = character(),
+      source = character(),
+      stringsAsFactors = FALSE
+    )
+  )
+})
+
 test_that("misc helpers [YSP-TEST-0136]", {
   expect_equal(yspec:::yml_rm("foo.yml"), "foo")
   expect_equal(yspec:::yml_rm("foo.yaml"), "foo")


### PR DESCRIPTION
Add a guard to summary.yspec (which is invoked by print.yspec) to prevent the following error on a zero-length list:

    > ys_select(ys_help$spec())
     Error in `$<-.data.frame`(`*tmp*`, info, value = "-") :
       replacement has 1 row, data has 0