### PR TITLE
Remove merge.list

### DIFF
--- a/R/class-yproject.R
+++ b/R/class-yproject.R
@@ -261,7 +261,7 @@ unpack_meta_yproj <- function(x,...) {
     meta[["data_path"]] <- "../data/derived"
   }
   updates <- list(...)
-  meta <- merge.list(meta,updates)
+  meta <- update_list(meta,updates)
   structure(x, meta = meta)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,29 +1,4 @@
-
-
-merge.list <- function(x,y,..., open=FALSE,
-                       warn=FALSE, context="object") {
-  
-  y <- as.list(y)
-  
-  ## Merge two lists
-  common <- intersect(names(x), names(y))
-  
-  x[common] <- y[common]
-  
-  if(open)  {
-    nw <- !is.element(names(y),names(x)) #| names(y) == wild
-    x <- c(x,y[nw])
-  } else {
-    if(length(common)==0 & warn) {
-      warning(
-        paste0("Found nothing to update: ", context),
-        call.=FALSE
-      )
-    }
-  }
-  x
-}
-
+# Replaces old merge.list(strict = TRUE) functionality
 combine_list <- function(left, right) {
   if(length(right)==0) return(left)
   if(!all(is.list(left),is.list(right))) {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -23,9 +23,6 @@ test_that("list operations [YSP-TEST-0116]", {
   
   x <- yspec:::update_list(a,b)
   expect_equal(x, list(a = 1, b = 4, c = 3))
-  
-  x <- yspec:::merge.list(a,b)
-  expect_equal(x,yspec:::update_list(a,b))
 })
 
 test_that("make_null [YSP-TEST-0117]", {


### PR DESCRIPTION
`merge.list()` was lifted from old `mrgsolve` code to work with named lists. It is way more flexible than what we need here (or what we need in mrgsolve, for that matter). `roxygen2` is now requesting that this function is exported as an S3 method. But it doesn't need to be a S3 method at all for this to work. 

Rather than exporting or renaming this function, remove it and use `update_list()`. There was already a test in the code base that showed these functions give the same result when updating a list with contents of another list. 