### PR TITLE
ci: update OS and check more R versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,11 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             r: 3.6.3
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             r: 4.0.5
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             r: 4.1.3
           - os: ubuntu-latest
             r: release

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,6 +23,10 @@ jobs:
             r: 4.0.5
           - os: ubuntu-22.04
             r: 4.1.3
+          - os: ubuntu-22.04
+            r: 4.2.3
+          - os: ubuntu-22.04
+            r: 4.3.1
           - os: ubuntu-latest
             r: release
     env:


### PR DESCRIPTION
 * update to `ubuntu-22.04` to prepare for the retirement of `ubuntu-20.04`.

 * add check jobs for R 4.2.3 and R 4.3.1 to cover the latest R versions on Metworx
