### PR TITLE
Release 0.7.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: yspec
 Type: Package
 Title: Data Specification for Pharmacometrics
-Version: 0.6.3.9000
+Version: 0.7.0
 Authors@R: c(
        person("Kyle T", "Baron", "", 
               "kyleb@metrumrg.com", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,16 @@
-# yspec (development version)
+# yspec 0.7.0
+
+- Added utilities to work with flags in the spec (#166), including 
+  - `ys_flags()` to extract a named list of flag data
+  - `ys_flags_chr()` to extract a character vector of flagged data names
+  - `ys_select_fl()` to select from a `yspec` object based on flagged
+    data names
+  - `ys_factors_fl()` to create factors in a data frame based on flagged 
+    data names
+
+- `ys_add_labels()` gains a `strict` argument, allowing the user to label
+  any data frame if there is at least one name in common between the `spec`
+  and the data frame (#167).
 
 # yspec 0.6.3
 


### PR DESCRIPTION
# yspec 0.7.0

- Added utilities to work with flags in the spec (#166), including 
  - `ys_flags()` to extract a named list of flag data
  - `ys_flags_chr()` to extract a character vector of flagged data names
  - `ys_select_fl()` to select from a `yspec` object based on flagged
    data names
  - `ys_factors_fl()` to create factors in a data frame based on flagged 
    data names

- `ys_add_labels()` gains a `strict` argument, allowing the user to label
  any data frame if there is at least one name in common between the `spec`
  and the data frame (#167).