### PR TITLE
Don't print unit in define.pdf that doesn't have at least one character

### DIFF
--- a/R/fda_define.R
+++ b/R/fda_define.R
@@ -21,7 +21,7 @@ pack_codes <- function(x) {
 as_fda_table_row <- function(x) {
   variable <- x[["col"]]
   label <- label(x, default = "short")
-  if(.has("unit", x)) {
+  if(.has("unit", x) && nchar(x$unit) > 0) {
     label <- paste0(label, " (unit: ", x$unit, ")")
   }
   tibble(

--- a/inst/spec/test/no-unit.yaml
+++ b/inst/spec/test/no-unit.yaml
@@ -1,0 +1,10 @@
+A: 
+  short: First 
+  unit: ""
+B: 
+  short: Second
+  unit: "ng/mL"
+C: 
+  short: Third
+  unit: ""
+  unit.add: "ng/mL"

--- a/tests/testthat/test-fda_define.R
+++ b/tests/testthat/test-fda_define.R
@@ -27,4 +27,13 @@ test_that("data_stem is respected in regulatory define [YSP-TEST-0040]", {
   expect_equal(basename(pr$xpt_file),paste0(pr$data_stem,".xpt"))
 })
 
-
+test_that("skip printing unit in define.pdf when blank", {
+  spec <- yspec:::test_spec_test("no-unit.yaml")
+  proj <- ys_project(spec)
+  m <- get_meta(proj)
+  ans <- fda_define(m$spec_file)
+  ans <- ans[grepl("^[A,B,C] \\&", ans)]
+  expect_no_match(ans[1], "unit")
+  expect_match(ans[2], "unit: ng/mL", fixed = TRUE)
+  expect_no_match(ans[3], "unit")
+})


### PR DESCRIPTION
See #174, where we sometimes set unit equal to `""` and don't want anything to show up in `define.pdf`. 