### PR TITLE
Add ys_document_namespace

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: yspec
 Type: Package
 Title: Data Specification for Pharmacometrics
-Version: 0.7.0
+Version: 0.7.0.9000
 Authors@R: c(
        person("Kyle T", "Baron", "", 
               "kyleb@metrumrg.com", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# yspec (development version)
+
 # yspec 0.7.0
 
 - Added utilities to work with flags in the spec (#166), including 

--- a/R/Aaaa.R
+++ b/R/Aaaa.R
@@ -43,7 +43,7 @@ VALID_SETUP_NAMES <- c(
   "spec_path", "glue", "use_internal_db", 
   "import", "character_last","comment_col", 
   "max_nchar_label", "max_nchar_col", "max_nchar_short", 
-  "flags"
+  "flags", "ys_document_namespace"
 )
 
 ys_control_defaults <- function() {

--- a/R/define.R
+++ b/R/define.R
@@ -269,7 +269,7 @@ define_for_rmd <- function(x,form_,proj=NULL,meta=NULL,tex=TRUE) {
   }
   
   if(isTRUE(tex)) {
-    specs <- map(specs, try_tex_namespace)
+    specs <- map(specs, ys_document_namespace)
   }
   
   tex <- imap(proj, .f = function(xi,.name) {

--- a/R/fda_define.R
+++ b/R/fda_define.R
@@ -136,7 +136,7 @@ fda_content_table <- function(x, ext=".xpt", loc=".") {
 ##' @export
 fda_table_file <- function(file) {
   x <- load_spec(file)
-  x <- try_tex_namespace(x)
+  x <- ys_document_namespace(x)
   fda_table(x)
 }
 
@@ -375,7 +375,7 @@ render_fda_define.yspec <- function(x, ..., dots = list()) {
 ys_table <- function(spec, fun = NULL, tex = TRUE, 
                      widths_ = c(0.75, 1.95, 0.6, 2.15), ...) {
   assert_that(is_yspec(spec))
-  spec <- try_tex_namespace(spec)
+  spec <- ys_document_namespace(spec)
   if(is.null(fun)) {
     tab <- fda_table(spec, widths = widths_, ...)  
   } else {

--- a/R/load_spec.R
+++ b/R/load_spec.R
@@ -154,6 +154,21 @@ check_for_err <- function(x, .fun, ...) {
   err
 }
 
+check_ys_document_namespace <- function(meta) {
+  if(is.null(meta[["ys_document_namespace"]])) {
+    return(invisible(NULL))
+  }
+  ns <- meta[["ys_document_namespace"]]
+  if(!all(ns %in% meta[["namespace"]])) {
+    bad <- setdiff(ns, meta[["namespace"]])
+    names(bad) <- rep("x", length(bad))
+    abort(
+      "namespace(s) in ys_document_namespace not found in the spec:", 
+      bad
+    )
+  }
+}
+
 capture_file_info <- function(x,file,where = "SETUP__") {
   x[[where]][["spec_file"]] <- file
   x[[where]][["spec_path"]] <- normalPath(dirname(file),mustWork=FALSE)
@@ -190,7 +205,9 @@ ys_load <- function(file, verbose = FALSE, ...) {
   x <- ys_load_file(file, verbose = verbose, ...)
   x <- unpack_spec(x, verbose = verbose)
   x <- add_flags(x)
-  set_namespace(x, "base")
+  x <- set_namespace(x, "base")
+  check_ys_document_namespace(x)
+  x
 }
 
 ##' @rdname ys_load
@@ -256,6 +273,7 @@ unpack_spec <- function(x, verbose = FALSE) {
     comment <- names(ans) %in% maybe_pull_meta(x, "comment_col")
     ans <- c(ans[(!chr) | comment], ans[chr & (!comment)])
   }
+  check_ys_document_namespace(m)
   ans
 }
 
@@ -274,7 +292,7 @@ unpack_meta <- function(x, to_update, verbose = FALSE, ...) {
     assert_that(is.character(meta[["lookup_file"]]))
     meta[["lookup_file"]] <- file.path(meta[["spec_path"]], meta[["lookup_file"]])
     meta[["lookup_file"]] <- normalPath(meta[["lookup_file"]], mustWork = FALSE)
-  }
+}
   if(.no("name", meta)) {
     meta[["name"]] <- basename(meta[["spec_file"]])
     meta[["name"]] <- tools::file_path_sans_ext(meta[["name"]])

--- a/R/load_spec.R
+++ b/R/load_spec.R
@@ -290,7 +290,7 @@ unpack_meta <- function(x, to_update, verbose = FALSE, ...) {
     assert_that(is.character(meta[["lookup_file"]]))
     meta[["lookup_file"]] <- file.path(meta[["spec_path"]], meta[["lookup_file"]])
     meta[["lookup_file"]] <- normalPath(meta[["lookup_file"]], mustWork = FALSE)
-}
+  }
   if(.no("name", meta)) {
     meta[["name"]] <- basename(meta[["spec_file"]])
     meta[["name"]] <- tools::file_path_sans_ext(meta[["name"]])

--- a/R/load_spec.R
+++ b/R/load_spec.R
@@ -205,8 +205,7 @@ ys_load <- function(file, verbose = FALSE, ...) {
   x <- ys_load_file(file, verbose = verbose, ...)
   x <- unpack_spec(x, verbose = verbose)
   x <- add_flags(x)
-  x <- set_namespace(x, "base")
-  x
+  set_namespace(x, "base")
 }
 
 ##' @rdname ys_load

--- a/R/load_spec.R
+++ b/R/load_spec.R
@@ -163,8 +163,8 @@ check_ys_document_namespace <- function(meta) {
     bad <- setdiff(ns, meta[["namespace"]])
     names(bad) <- rep("x", length(bad))
     abort(
-      "namespace(s) in ys_document_namespace not found in the spec:", 
-      bad
+      message = "ys_document_namespace in SETUP__ not found in spec:", 
+      body = bad
     )
   }
 }

--- a/R/load_spec.R
+++ b/R/load_spec.R
@@ -206,7 +206,6 @@ ys_load <- function(file, verbose = FALSE, ...) {
   x <- unpack_spec(x, verbose = verbose)
   x <- add_flags(x)
   x <- set_namespace(x, "base")
-  check_ys_document_namespace(x)
   x
 }
 

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -143,10 +143,11 @@ try_tex_namespace <- function(x) {
 }
 
 ys_document_namespace <- function(x) {
-  x <- try_tex_namespace(x)
   ns <- maybe_pull_meta(x, "ys_document_namespace")
   if(is.character(ns)) {
     x <- ys_namespace(x, ns)
+  } else {
+    x <- try_tex_namespace(x)
   }
   x
 }

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -148,8 +148,8 @@ ys_document_namespace <- function(x) {
   if(is.character(ns)) {
     x <- ys_namespace(x, ns)
   }
+  x
 }
-
 
 current_namespace <- function(x) {
   attr(x, "namespace")

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -142,6 +142,15 @@ try_tex_namespace <- function(x) {
   x
 }
 
+ys_document_namespace <- function(x) {
+  x <- try_tex_namespace(x)
+  ns <- maybe_pull_meta(x, "ys_document_namespace")
+  if(is.character(ns)) {
+    x <- ys_namespace(x, ns)
+  }
+}
+
+
 current_namespace <- function(x) {
   attr(x, "namespace")
 }

--- a/inst/internal/analysis1.yml
+++ b/inst/internal/analysis1.yml
@@ -12,6 +12,7 @@ SETUP__:
     cat: [SEQ, STUDY]
   lookup_file: "look.yml"
   extend_file: "analysis1-ext.yml"
+  ys_document_namespace: define
 C:
 NUM:
 ID:
@@ -76,6 +77,7 @@ TAD:
 LDOS:
   short: last dose amount
   unit: mg
+  unit.define: milligrams
 MDV:
 BLQ:
   short: below limit of quantification

--- a/inst/internal/analysis1.yml
+++ b/inst/internal/analysis1.yml
@@ -12,7 +12,7 @@ SETUP__:
     cat: [SEQ, STUDY]
   lookup_file: "look.yml"
   extend_file: "analysis1-ext.yml"
-  ys_document_namespace: define
+  ys_document_namespace: [tex, define]
 C:
 NUM:
 ID:

--- a/tests/testthat/test-define.R
+++ b/tests/testthat/test-define.R
@@ -22,20 +22,17 @@ test_that("define [YSP-TEST-0031]", {
   
 })
 
-# test_that("md_outline", {
-#   sp <- load_spec_ex(("DEM104101F_PK.yml"))
-#   expect_is(sp, "yspec [YSP-TEST-0086]")
-#   pr <- ys_project(sp)
-#   expect_is(pr,"yproj")
-#   yamlfile <- pull_meta(pr,"spec_file")
-#   ans <- define_for_rmd(yamlfile,"md_outline")
-#   expect_is(ans,"character")
-# })
-# 
-# test_that("pander_table", {
-#   pr <- ys_project_file(file_spec_ex("DEM104101F_PK.yml"))
-#   expect_is(pr,"yproj")
-#   yamlfile <- ys_spec_file(pr)
-#   ans <- define_for_rmd(yamlfile,"pander_table")
-#   expect_is(ans,"character")
-# })
+test_that("ys_document_namespace is invoked on render define", {
+  spec <- ys_help$spec()
+  temp <- tempdir()
+  x <- ys_document(
+    spec, 
+    run_pandoc = FALSE, 
+    build_dir = temp, 
+    quiet = TRUE
+  )
+  lines <- readLines(file.path(temp,x))
+  lines <- lines[grepl("LDOS", lines)]
+  expect_match(lines, "(milligrams)", fixed = TRUE)
+  expect_equal(spec$LDOS$unit, "mg")
+})

--- a/tests/testthat/test-fda_define.R
+++ b/tests/testthat/test-fda_define.R
@@ -37,3 +37,19 @@ test_that("skip printing unit in define.pdf when blank", {
   expect_match(ans[2], "unit: ng/mL", fixed = TRUE)
   expect_no_match(ans[3], "unit")
 })
+
+test_that("ys_document_namespace is invoked on render fda define", {
+  spec <- ys_help$spec()
+  temp <- tempdir()
+  x <- ys_document(
+    spec, 
+    run_pandoc = FALSE, 
+    build_dir = temp, 
+    type = "regulatory", 
+    quiet = TRUE
+  )
+  lines <- readLines(file.path(temp,x))
+  lines <- lines[grepl("LDOS", lines)]
+  expect_match(lines, "unit: milligrams", fixed = TRUE)
+  expect_equal(spec$LDOS$unit, "mg")
+})

--- a/tests/testthat/test-load_spec.R
+++ b/tests/testthat/test-load_spec.R
@@ -135,3 +135,15 @@ test_that("ys_load - only assume character type if type is NULL [YSP-TEST-0145]"
   )
   expect_equal(spec$A$type, "integer")
 })
+
+test_that("error when ys_document_namespace doesn't name an actual namespace", {
+  a <- list(A = list(unit = "mg", unit.foo = "milligrams"))
+  spec <- yspec:::test_spec_list(a, setup = list(ys_document_namespace = "foo"))
+  expect_is(spec, "yspec")
+  expect_equal(pull_meta(spec, "ys_document_namespace"), "foo")
+  expect_error(
+    spec <- yspec:::test_spec_list(a, setup = list(ys_document_namespace = "bar")), 
+    "ys_document_namespace in SETUP__ not found in spec", 
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-namespace.R
+++ b/tests/testthat/test-namespace.R
@@ -58,3 +58,19 @@ test_that("multiple namespaces are handled properly [YSP-TEST-0080]", {
   expect_identical(lc$STUDY$decode, c("phase 1", "phase 2", "phase 3"))
   expect_identical(uc$STUDY$decode, c("PHASE 1", "PHASE 2", "PHASE 3"))
 })
+
+test_that("ys_document_namespace invokes only user-input selections", {
+  spec <- yspec:::test_spec_list(
+    list(
+      A = list(short = "foo", short.define = "bar", short.tex = "yak"), 
+      B = list(short = "base_short", short.tex = "tex_short")
+    ), 
+    setup = list(ys_document_namespace = "define")
+  )
+  spec <- yspec:::ys_document_namespace(spec)
+  expect_equal(pull_meta(spec, "namespace"), c("base", "define", "tex"))
+  # Selects namespace in ys_document_namespace
+  expect_equal(spec$A$short, "bar")
+  # Didn't invoke tex namespace b/c it wasn't in user input
+  expect_equal(spec$B$short, "base_short")
+})


### PR DESCRIPTION
See https://github.com/metrumresearchgroup/yspec/pull/175 for history on why we need to invoke a specific namespace when rendering `define.pdf` and other similar data definition documents. 

Passing `ns` is not a viable approach since we most often want to render a `yproj` object and some specs may have the namespace, some specs may not. 

This PR replaces #175, taking another approach. 

Here, we add `ys_document_namespace` as spec meta data field. 

```yaml
SETUP__:
  description: Example PopPK analysis data set
  ... 
  lookup_file: look.yml
  extend_file: analysis1-ext.yml
  ys_document_namespace: [tex, define]
```


When the spec is rendered, we call the new function `ys_document_namespace()`, which 

1. Tries to load the namespaces in listed in `SETUP___: ys_document_namespace`
2. Tries to load the `tex` namespace by default if nothing was found in 1.
 
So if the user specifies `ys_document_namespace`, that defines the complete set of namespaces that will be invoked during render to pdf. 

A check has been added on load to make sure the `ys_document_namespace` exists as a valid namespace.

This should be a much, much cleaner approach. I don't love the name, but hopefully use is rare and it won't matter. But very open to suggestions; will change in a heartbeat.

The other advantage to this is it forces the user to write the behavior into the spec rather than specify ad-hoc when making define.pdf. 

