### PR TITLE
Correctly specify file extension in section header

### DIFF
--- a/R/fda_define.R
+++ b/R/fda_define.R
@@ -183,16 +183,16 @@ fda_content_table_loc <- function(data_file,loc) {
 ##' @seealso [fda_table()]
 ##' @md
 ##' @export
-fda_define <- function(file, title="Datasets", ext=".xpt", loc=".",...) {
+fda_define <- function(file, title = "Datasets", ext = ".xpt", loc = ".",...) {
   
   x <- load_spec_proj(file)
   
   main <- paste0("# ", title)
 
-  contents <- fda_content_table(x, ext=ext, loc=loc, ...)
+  contents <- fda_content_table(x, ext = ext, loc = loc, ...)
   
   specs <- map(x, function(this) {
-    title <- paste0(this$description, " (`", this$data_file, "`)")
+    title <- paste0(this$description, " (`", this$data_stem, ext, "`)")
     header <- paste0("## ", title, " \\label{", this$name,"}")
     c(header, "\\noindent", " ", "  ", fda_table_file(this$spec_file))
   })


### PR DESCRIPTION
See #136 The files under "Datasets" had the correct extension; it was the files in the section header that did not. 

@juliakorell Could you please confirm the patch code I gave you on Slack fixes the issue?


```r
library(ysepc)
proj <- ys_help$proj()

ys_document(proj, type = "regulatory", ext = ".df")

```


<img width="1104" height="851" alt="Screenshot 2026-05-04 at 15 59 11" src="https://github.com/user-attachments/assets/0f893e01-ef5d-4574-a0ca-f38923788aea" />
