### PR TITLE
Release 0.8.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: yspec
 Type: Package
 Title: Data Specification for Pharmacometrics
-Version: 0.7.0.9000
+Version: 0.8.0
 Authors@R: c(
        person("Kyle T", "Baron", "", 
               "kyleb@metrumrg.com", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,21 @@
-# yspec (development version)
+# yspec 0.8.0
+
+- `ys_document()` no longer prints `unit` in define.pdf when it is set to an
+  empty string (#173).
+
+- `ys_add_factors()` and `ys_factors()` now retain attributes on data columns
+  that are converted to factors (#177).
+
+- `ys_extend()` and `ys_join()` now properly copy namespace information from
+  the extension spec to the parent, so namespaces defined only in an extension
+  spec are recognized without error (#179).
+
+- Added `ys_document_namespace` as a `SETUP__` meta field to control which
+  namespaces are invoked when rendering define.pdf; falls back to the `tex`
+  namespace by default (#180).
+
+- Fixed a bug in the regulatory define.pdf where the file extension was
+  incorrect in section headers (#181).
 
 # yspec 0.7.0
 

--- a/tests/testthat/test-namespace.R
+++ b/tests/testthat/test-namespace.R
@@ -76,6 +76,8 @@ test_that("yspec:::list_namespaces preserves order", {
   ))  
   x <- yspec:::list_namespaces(spec)
   expect_equal(x, c("base", "ZZZ", "n", "AAA", "m"))
+})
+
 test_that("ys_document_namespace invokes only user-input selections", {
   spec <- yspec:::test_spec_list(
     list(


### PR DESCRIPTION
## yspec 0.8.0

- `ys_document()` no longer prints `unit` in define.pdf when it is set to an
  empty string (#173).

- `ys_add_factors()` and `ys_factors()` now retain attributes on data columns
  that are converted to factors (#177).

- `ys_extend()` and `ys_join()` now properly copy namespace information from
  the extension spec to the parent, so namespaces defined only in an extension
  spec are recognized without error (#179).

- Added `ys_document_namespace` as a `SETUP__` meta field to control which
  namespaces are invoked when rendering define.pdf; falls back to the `tex`
  namespace by default (#180).

- Fixed a bug in the regulatory define.pdf where the file extension was
  incorrect in section headers (#181).